### PR TITLE
Error handling cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this this project will be documented in this file.
 The format is based on [changelog.md](https://changelog.md/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2021-02-08
+- Add timeout and swallow error command line options
+- Ensure that unsuccessful scan still return a valid JARM fingerprint (00000000000000000000000000000000000000000000000000000000000000)
+
 ## [0.0.4] - 2021-01-28
 - Add improved command line support
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ pip install pyjarm
 
 ### Command Line
 ```
-usage: pyjarm [-h] [-i INPUT] [-d] [-o OUTPUT] [-4] [-6] [-c [CONCURRENCY]] [--proxy PROXY]
-                   [--proxy-auth PROXY_AUTH] [--proxy-insecure]
-                   [scan]
+usage: jarm [-h] [-i INPUT] [-d] [-o OUTPUT] [-4] [-6] [-c [CONCURRENCY]]
+            [--proxy PROXY] [--proxy-auth PROXY_AUTH] [--proxy-insecure]
+            [--timeout TIMEOUT] [--suppress]
+            [scan]
 
 Enter an IP address/domain and port to scan or supply an input file.
 
@@ -33,20 +34,34 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -i INPUT, --input INPUT
-                        Provide a list of IP addresses or domains to scan, one domain or IP address per line. Ports
-                        can be specified with a colon (ex. 8.8.8.8:8443)
-  -d, --debug           [OPTIONAL] Debug mode: Displays additional debug details
+                        Provide a list of IP addresses or domains to scan, one
+                        domain or IP address per line. Ports can be specified
+                        with a colon (ex. 8.8.8.8:8443)
+  -d, --debug           [OPTIONAL] Debug mode: Displays additional debug
+                        details
   -o OUTPUT, --output OUTPUT
-                        [OPTIONAL] Provide a filename to output/append results to a CSV file.
-  -4, --ipv4only        [OPTIONAL] Use only IPv4 connections (incompatible with --ipv6only).
-  -6, --ipv6only        [OPTIONAL] Use only IPv6 connections (incompatible with --ipv4only).
+                        [OPTIONAL] Provide a filename to output/append results
+                        to a CSV file.
+  -4, --ipv4only        [OPTIONAL] Use only IPv4 connections (incompatible
+                        with --ipv6only).
+  -6, --ipv6only        [OPTIONAL] Use only IPv6 connections (incompatible
+                        with --ipv4only).
   -c [CONCURRENCY], --concurrency [CONCURRENCY]
-                        [OPTIONAL] Number of concurrent connections (default is 2).
-  --proxy PROXY         [OPTIONAL] Use proxy (format http[s]://user:pass@proxy:port). HTTPS_PROXY env variable is used
-                        by default if this is not set. Set this to 'ignore' to ignore HTTPS_PROXY and use no proxy.
+                        [OPTIONAL] Number of concurrent connections (default
+                        is 2).
+  --proxy PROXY         [OPTIONAL] Use proxy (format
+                        http[s]://user:pass@proxy:port). HTTPS_PROXY env
+                        variable is used by default if this is not set. Set
+                        this to 'ignore' to ignore HTTPS_PROXY and use no
+                        proxy.
   --proxy-auth PROXY_AUTH
-                        [OPTIONAL] Send this header in Proxy-Authorization (when using proxy).
-  --proxy-insecure      [OPTIONAL] Do not verify SSL_CERTIFICATES (only when HTTPS proxy is set).
+                        [OPTIONAL] Send this header in Proxy-Authorization
+                        (when using proxy).
+  --proxy-insecure      [OPTIONAL] Do not verify SSL_CERTIFICATES (only when
+                        HTTPS proxy is set).
+  --timeout TIMEOUT     [OPTIONAL] Timeout to wait for connection attempts.
+                        Default is 20 seconds
+  --suppress            [OPTIONAL] Suppresses any exception or warning logging.
 ```
 
 **Example**

--- a/jarm/__init__.py
+++ b/jarm/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "Andrew Scott"
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 __license__ = "ISC"
 __status__ = "Development"

--- a/jarm/connection/connection.py
+++ b/jarm/connection/connection.py
@@ -4,15 +4,13 @@ from typing import Tuple, Dict, Any
 from enum import IntEnum
 import ssl
 
+from jarm.constants import DEFAULT_TIMEOUT
 from jarm.proxy.proxy import Proxy
 from jarm.exceptions.exceptions import PyJARMInvalidProxy
 from jarm.validate.validate import Validate
 
 
 class Connection:
-
-    DEFAULT_TIMEOUT = 20  # default timeout in seconds
-
     class AddressFamily(IntEnum):
         AF_ANY = 0
         AF_INET = 2
@@ -65,7 +63,7 @@ class Connection:
 
         timeout = connect_args.get("timeout")
         if not timeout or not isinstance(timeout, int):
-            timeout = Connection.DEFAULT_TIMEOUT
+            timeout = DEFAULT_TIMEOUT
 
         proxy_string = connect_args.get("proxy")
         if proxy_string and not isinstance(proxy_string, str):

--- a/jarm/constants.py
+++ b/jarm/constants.py
@@ -62,3 +62,6 @@ TOTAL_FAILURE: str = "|||,|||,|||,|||,|||,|||,|||,|||,|||,|||"
 FAILED_PACKET: str = "|||"
 ERROR_INC_1: bytes = b"\x0e\xac\x0b"
 ERROR_INC_2: bytes = b"\x0f\xf0\x0b"
+
+# CONNECTION
+DEFAULT_TIMEOUT = 20

--- a/jarm/scanner/scanner.py
+++ b/jarm/scanner/scanner.py
@@ -107,12 +107,6 @@ class Scanner:
                 for r in result_list:
                     if p[0] == r[0]:
                         results.append(Scanner._parse_server_hello(r[1], p))
-        except OSError:
-            if not suppress:
-                logging.exception(
-                    f"Socket Exception scanning {target} - is the address resolvable?"
-                )
-            return Hasher.jarm(TOTAL_FAILURE), target.host, target.port
         except Exception:
             if not suppress:
                 logging.exception(f"Unknown Exception scanning {target}")


### PR DESCRIPTION
## Description

- Ensure we always return a valid JARM, even on unsuccessful scans. Previously we returned 
  ```JARM: |||,|||,|||,|||,|||,|||,|||,|||,|||,|||``` when we should really return ```JARM: 00000000000000000000000000000000000000000000000000000000000000```
- Make sure timeout value is respected and allow to be passed from command line
- Add `suppress` option to command line to ensure that noisy stack-traces and warnings and not returned to stdout.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes are in part to address issue #11 

## How Has This Been Tested?

Tested manually

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
