### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/jarm/connection/connection.py
+++ b/jarm/connection/connection.py
@@ -18,7 +18,7 @@ class Connection:
 
     @staticmethod
     async def prep_connection(
-        connect_target: Dict[str, Any]
+        connect_target: Dict[str, Any],
     ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         reader, writer = await asyncio.open_connection(
             host=connect_target.get("connect_host"),


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions